### PR TITLE
Fix preflight to run the role over SSH

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -3,18 +3,8 @@
 
 # Preflight checks
 
-- name: Preflight - Lookup operating-system id
-  set_fact:
-    os_id: "{{ lookup('ini', 'ID type=properties file=/etc/os-release') | regex_replace('\"','') }}"
-  tags: always
-
-- name: Preflight - Lookup operating system version
-  set_fact:
-    os_version: "{{ lookup('ini', 'VERSION type=properties file=/etc/os-release') | regex_replace('\"','') }}"
-  tags: always
-
 - name: Preflight - Fail if host is not suitable for this benchmark
   fail:
     msg: "This benchmark is not suitable for the destination operating system"
-  when: (os_id is not defined) or (os_version is not defined) or (os_version not in cis_target_os_versions) or (os_id != cis_target_os_id)
+  when: (ansible_distribution is not defined) or (ansible_distribution_version is not defined) or (ansible_distribution_version not in cis_target_os_versions) or (ansible_distribution != cis_target_os_distribution)
   tags: always

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 # Standards: 0.11
 ---
 
-cis_target_os_id: "amzn"
+cis_target_os_distribution: "Amazon"
 cis_target_os_versions: 
   - "2016.03"
   - "2016.09"


### PR DESCRIPTION
Right now the preflight only works properly when running ansible in the localhost because of the usage of lookups. This makes the role unusable over SSH. According to http://docs.ansible.com/ansible/playbooks_lookups.html:

`Lookups occur on the local computer, not on the remote computer`

This PR replaces the old custom facts defined using lookups with the standard facts ansible_distribution and ansible_distribution_version. 