### PR TITLE
Enable Check Mode for tasks 6.2.x

### DIFF
--- a/tasks/level-1/6.2.10.yml
+++ b/tasks/level-1/6.2.10.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.10 - Audit users' dot files permissions
   script: "{{ role_path }}/files/audit_6.2.10.sh"
+  always_run: yes
   register: audit_6_2_10
   tags:
     - level-1

--- a/tasks/level-1/6.2.11.yml
+++ b/tasks/level-1/6.2.11.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.11 - Audit users' forward files
   script: "{{ role_path }}/files/audit_6.2.11.sh"
+  always_run: yes
   register: audit_6_2_11
   tags:
     - level-1

--- a/tasks/level-1/6.2.12.yml
+++ b/tasks/level-1/6.2.12.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.12 - Audit users'.netrc files
   script: "{{ role_path }}/files/audit_6.2.12.sh"
+  always_run: yes
   register: audit_6_2_12
   tags:
     - level-1

--- a/tasks/level-1/6.2.13.yml
+++ b/tasks/level-1/6.2.13.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.13 - Audit users'.netrc permissions
   script: "{{ role_path }}/files/audit_6.2.13.sh"
+  always_run: yes
   register: audit_6_2_13
   tags:
     - level-1

--- a/tasks/level-1/6.2.14.yml
+++ b/tasks/level-1/6.2.14.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.14 - Audit users'.rhosts files
   script: "{{ role_path }}/files/audit_6.2.14.sh"
+  always_run: yes
   register: audit_6_2_14
   tags:
     - level-1

--- a/tasks/level-1/6.2.15.yml
+++ b/tasks/level-1/6.2.15.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.15 - Audit existence of groups listed in /etc/passwd against /etc/group
   script: "{{ role_path }}/files/audit_6.2.15.sh"
+  always_run: yes
   register: audit_6_2_15
   tags:
     - level-1

--- a/tasks/level-1/6.2.16.yml
+++ b/tasks/level-1/6.2.16.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.16 - Check if duplicate UIDs exist
   script: "{{ role_path }}/files/audit_6.2.16.sh"
+  always_run: yes
   register: audit_6_2_16
   tags:
     - level-1

--- a/tasks/level-1/6.2.17.yml
+++ b/tasks/level-1/6.2.17.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.17 - Check if duplicate GIDs exist
   script: "{{ role_path }}/files/audit_6.2.17.sh"
+  always_run: yes
   register: audit_6_2_17
   tags:
     - level-1

--- a/tasks/level-1/6.2.18.yml
+++ b/tasks/level-1/6.2.18.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.18 - Check if duplicate user names exist
   script: "{{ role_path }}/files/audit_6.2.18.sh"
+  always_run: yes
   register: audit_6_2_18
   tags:
     - level-1

--- a/tasks/level-1/6.2.19.yml
+++ b/tasks/level-1/6.2.19.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.19 - Check if duplicate group names exist
   script: "{{ role_path }}/files/audit_6.2.19.sh"
+  always_run: yes
   register: audit_6_2_19
   tags:
     - level-1

--- a/tasks/level-1/6.2.7.yml
+++ b/tasks/level-1/6.2.7.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.7 - Audit existence of users' home directories
   script: "{{ role_path }}/files/audit_6.2.7.sh"
+  always_run: yes
   register: audit_6_2_7
   tags:
     - level-1

--- a/tasks/level-1/6.2.8.yml
+++ b/tasks/level-1/6.2.8.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.8 - Audit users' home directories permissions
   script: "{{ role_path }}/files/audit_6.2.8.sh"
+  always_run: yes
   register: audit_6_2_8
   tags:
     - level-1

--- a/tasks/level-1/6.2.9.yml
+++ b/tasks/level-1/6.2.9.yml
@@ -5,6 +5,7 @@
 
 - name: 6.2.9 - Audit ownership of users' home directories
   script: "{{ role_path }}/files/audit_6.2.9.sh"
+  always_run: yes
   register: audit_6_2_9
   tags:
     - level-1


### PR DESCRIPTION
Tasks 6.2.x use proper audit scripts that doesn't change anything on the system, those scripts can be executed even in Check Mode to retrieve the necessary data and avoid the role to crash when running in Check mode (-C)