### PR TITLE
Minor improvements

### DIFF
--- a/files/audit_6.2.10.sh
+++ b/files/audit_6.2.10.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for dir in `cat /etc/passwd | egrep -v '(root|sync|halt|shutdown)' | awk -F: '($7 != "/sbin/nologin") { print $6 }'`; do
+for dir in `cat /etc/passwd | egrep -v '^(root|sync|halt|shutdown):' | awk -F: '($7 != "/sbin/nologin") { print $6 }'`; do
   for file in $dir/.[A-Za-z0-9]*; do
     if [ ! -h "$file" -a -f "$file" ]; then
       fileperm=`ls -ld $file | cut -f1 -d" "`

--- a/files/audit_6.2.15.sh
+++ b/files/audit_6.2.15.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
  
-for i in $(cut -s -d: -f4 /etc/passwd | sort -u ); do
-  grep -q -P "^.*?:[^:]*:$i:" /etc/group
-  if [ $? -ne 0 ]; then
-    echo "Group $i is referenced by /etc/passwd but does not exist in /etc/group"
-  fi
+comm -23 <(cut -s -d: -f4 /etc/passwd | sort -u) <(cut -s -d: -f3 /etc/group | sort -u) | while read GROUP ; do
+  echo "Group $GROUP is referenced by /etc/passwd but does not exist in /etc/group"
 done

--- a/files/audit_6.2.16.sh
+++ b/files/audit_6.2.16.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-cat /etc/passwd | cut -f3 -d":" | sort -n | uniq -c | while read x ; do
-  [ -z "${x}" ] && break
-  set - $x
-  if [ $1 -gt 1 ]; then
-    users=`awk -F: '($3 == n) { print $1 }' n=$2 /etc/passwd | xargs`
-    echo "Duplicate UID ($2): ${users}"
-  fi
+FILE=/etc/passwd
+
+grep -v '^#' $FILE | cut -f3 -d":" | sort -n | uniq -d | while read DUPE ; do
+  users=`awk -F: '($3 == n) { print $1 }' n="$DUPE" $FILE`
+  echo "Duplicate UID ($DUPE): ${users}"
 done

--- a/files/audit_6.2.17.sh
+++ b/files/audit_6.2.17.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-cat /etc/group | cut -f3 -d":" | sort -n | uniq -c | while read x ; do
-  [ -z "${x}" ] && break
-  set - $x
-  if [ $1 -gt 1 ]; then
-    groups=`awk -F: '($3 == n) { print $1 }' n=$2 /etc/group | xargs`
-    echo "Duplicate GID ($2): ${groups}"
-  fi
+FILE=/etc/group
+
+grep -v '^#' $FILE | cut -f3 -d":" | sort -n | uniq -d | while read DUPE ; do
+  groups=`awk -F: '($3 == n) { print $1 }' n=$DUPE $FILE`
+  echo "Duplicate GID ($DUPE): ${groups}"
 done


### PR DESCRIPTION
Minor improvements to some audit shell scripts:

- audit_6.2.10.sh: put anchors around a regexp so as not to match too much
- audit_6.2.15.sh: eliminated an unnecessary loop through every user on the system
- audit_6.2.1[57].sh: replaced `uniq -c` by `uniq -d` for efficiency and simplicity