### PR TITLE
Identifying check_mode-safe information gatherers with always_run and…

### DIFF
--- a/tasks/level-1/1.5.2.yml
+++ b/tasks/level-1/1.5.2.yml
@@ -6,6 +6,8 @@
 - name: 1.5.2 - Check if XD/NX support is enabled
   shell: "dmesg | grep NX"
   register: dmesg_1_5_2
+  always_run: yes
+  changed_when: False
   ignore_errors: true
   tags:
     - level-1

--- a/tasks/level-1/5.4.1.1.yml
+++ b/tasks/level-1/5.4.1.1.yml
@@ -6,6 +6,8 @@
 - name: 5.4.1.1 - Obtain a list of user accounts
   shell: "egrep ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1"
   register: egrep_5_4_1_1
+  always_run: yes
+  changed_when: False
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.4.1.2.yml
+++ b/tasks/level-1/5.4.1.2.yml
@@ -6,6 +6,8 @@
 - name: 5.4.1.2 - Obtain a list of user accounts
   shell: "egrep ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1"
   register: egrep_5_4_1_2
+  always_run: yes
+  changed_when: False
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.4.1.3.yml
+++ b/tasks/level-1/5.4.1.3.yml
@@ -6,6 +6,8 @@
 - name: 5.4.1.3 - Obtain a list of user accounts
   shell: "egrep ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1"
   register: egrep_5_4_1_3
+  always_run: yes
+  changed_when: False
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.4.1.4.yml
+++ b/tasks/level-1/5.4.1.4.yml
@@ -6,6 +6,8 @@
 - name: 5.4.1.4 - Obtain a list of user accounts
   shell: "egrep ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1"
   register: egrep_5_4_1_4
+  always_run: yes
+  changed_when: False
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.4.2.yml
+++ b/tasks/level-1/5.4.2.yml
@@ -6,6 +6,8 @@
 - name: 5.4.2 - Retrieve system accounts
   shell: "awk -F: '($3 < 500) {print $1 }' /etc/passwd | grep -v ^#"
   register: audit_5_4_2
+  always_run: yes
+  changed_when: False
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.4.3.yml
+++ b/tasks/level-1/5.4.3.yml
@@ -6,6 +6,8 @@
 - name: 5.4.3 - Check the GID of the root group
   shell: "cat /etc/passwd | awk -F: '($3 == 0) { print $1 }'"
   register: cat_5_4_3
+  always_run: yes
+  changed_when: False
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/6.2.1.yml
+++ b/tasks/level-1/6.2.1.yml
@@ -6,6 +6,8 @@
 - name: 6.2.1 - Identify any accounts without passwords
   shell: "cat /etc/shadow | awk -F: '($2 == \"\" ) { print $1 }'"
   register: accounts_6_2_1
+  always_run: yes
+  changed_when: False
   tags: 
     - level-1
     - section-6

--- a/tasks/level-1/6.2.10.yml
+++ b/tasks/level-1/6.2.10.yml
@@ -6,6 +6,7 @@
 - name: 6.2.10 - Audit users' dot files permissions
   script: "{{ role_path }}/files/audit_6.2.10.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_10
   tags:
     - level-1

--- a/tasks/level-1/6.2.11.yml
+++ b/tasks/level-1/6.2.11.yml
@@ -6,6 +6,7 @@
 - name: 6.2.11 - Audit users' forward files
   script: "{{ role_path }}/files/audit_6.2.11.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_11
   tags:
     - level-1

--- a/tasks/level-1/6.2.12.yml
+++ b/tasks/level-1/6.2.12.yml
@@ -6,6 +6,7 @@
 - name: 6.2.12 - Audit users'.netrc files
   script: "{{ role_path }}/files/audit_6.2.12.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_12
   tags:
     - level-1

--- a/tasks/level-1/6.2.13.yml
+++ b/tasks/level-1/6.2.13.yml
@@ -6,6 +6,7 @@
 - name: 6.2.13 - Audit users'.netrc permissions
   script: "{{ role_path }}/files/audit_6.2.13.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_13
   tags:
     - level-1

--- a/tasks/level-1/6.2.14.yml
+++ b/tasks/level-1/6.2.14.yml
@@ -6,6 +6,7 @@
 - name: 6.2.14 - Audit users'.rhosts files
   script: "{{ role_path }}/files/audit_6.2.14.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_14
   tags:
     - level-1

--- a/tasks/level-1/6.2.15.yml
+++ b/tasks/level-1/6.2.15.yml
@@ -6,6 +6,7 @@
 - name: 6.2.15 - Audit existence of groups listed in /etc/passwd against /etc/group
   script: "{{ role_path }}/files/audit_6.2.15.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_15
   tags:
     - level-1

--- a/tasks/level-1/6.2.16.yml
+++ b/tasks/level-1/6.2.16.yml
@@ -6,6 +6,7 @@
 - name: 6.2.16 - Check if duplicate UIDs exist
   script: "{{ role_path }}/files/audit_6.2.16.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_16
   tags:
     - level-1

--- a/tasks/level-1/6.2.17.yml
+++ b/tasks/level-1/6.2.17.yml
@@ -6,6 +6,7 @@
 - name: 6.2.17 - Check if duplicate GIDs exist
   script: "{{ role_path }}/files/audit_6.2.17.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_17
   tags:
     - level-1

--- a/tasks/level-1/6.2.18.yml
+++ b/tasks/level-1/6.2.18.yml
@@ -6,6 +6,7 @@
 - name: 6.2.18 - Check if duplicate user names exist
   script: "{{ role_path }}/files/audit_6.2.18.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_18
   tags:
     - level-1

--- a/tasks/level-1/6.2.19.yml
+++ b/tasks/level-1/6.2.19.yml
@@ -6,6 +6,7 @@
 - name: 6.2.19 - Check if duplicate group names exist
   script: "{{ role_path }}/files/audit_6.2.19.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_19
   tags:
     - level-1

--- a/tasks/level-1/6.2.5.yml
+++ b/tasks/level-1/6.2.5.yml
@@ -5,6 +5,8 @@
 
 - name: 6.2.5 - Ensure root is the only UID 0 account
   shell: "cat /etc/passwd | awk -F: '($3 == 0) { print $1 }'"
+  always_run: yes
+  changed_when: False
   register: cat_6_2_5
   tags:
     - level-1

--- a/tasks/level-1/6.2.6.yml
+++ b/tasks/level-1/6.2.6.yml
@@ -5,6 +5,8 @@
 
 - name: 6.2.6 - Audit root PATH Integrity
   script: "{{ role_path }}/files/audit_6.2.6.sh"
+  always_run: yes
+  changed_when: False
   register: audit_6_2_6
   tags:
     - level-1

--- a/tasks/level-1/6.2.7.yml
+++ b/tasks/level-1/6.2.7.yml
@@ -6,6 +6,7 @@
 - name: 6.2.7 - Audit existence of users' home directories
   script: "{{ role_path }}/files/audit_6.2.7.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_7
   tags:
     - level-1

--- a/tasks/level-1/6.2.8.yml
+++ b/tasks/level-1/6.2.8.yml
@@ -6,6 +6,7 @@
 - name: 6.2.8 - Audit users' home directories permissions
   script: "{{ role_path }}/files/audit_6.2.8.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_8
   tags:
     - level-1

--- a/tasks/level-1/6.2.9.yml
+++ b/tasks/level-1/6.2.9.yml
@@ -6,6 +6,7 @@
 - name: 6.2.9 - Audit ownership of users' home directories
   script: "{{ role_path }}/files/audit_6.2.9.sh"
   always_run: yes
+  changed_when: False
   register: audit_6_2_9
   tags:
     - level-1


### PR DESCRIPTION
… changed_when

Scripts that only gather information to be used in later tasks, and do not modify the system, should be identifed with

 - "always_run: yes" so that they will run in check mode (as of ansible 2.2 it should be "check_mode: no" but that is less readable and as per the README the playbook is to be compatible with Ansible 2.0.2 and 2.1.3).

 - "changed_when: false" to avoid the tasks being marked as having changed the system