### PR TITLE
chmod u+x /etc/cron.d/

### DIFF
--- a/tasks/level-1/5.1.3.yml
+++ b/tasks/level-1/5.1.3.yml
@@ -8,7 +8,7 @@
     path: "/etc/cron.hourly"
     owner: root
     group: root
-    mode: 0600
+    mode: 0700
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.1.4.yml
+++ b/tasks/level-1/5.1.4.yml
@@ -8,7 +8,7 @@
     path: "/etc/cron.daily"
     owner: root
     group: root
-    mode: 0600
+    mode: 0700
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.1.5.yml
+++ b/tasks/level-1/5.1.5.yml
@@ -8,7 +8,7 @@
     path: "/etc/cron.weekly"
     owner: root
     group: root
-    mode: 0600
+    mode: 0700
   tags:
     - level-1
     - section-5

--- a/tasks/level-1/5.1.6.yml
+++ b/tasks/level-1/5.1.6.yml
@@ -8,7 +8,7 @@
     path: "/etc/cron.monthly"
     owner: root
     group: root
-    mode: 0600
+    mode: 0700
   tags:
     - level-1
     - section-6

--- a/tasks/level-1/5.1.7.yml
+++ b/tasks/level-1/5.1.7.yml
@@ -8,7 +8,7 @@
     path: "/etc/cron.d"
     owner: root
     group: root
-    mode: 0600
+    mode: 0700
     state: directory
   tags:
     - level-1


### PR DESCRIPTION
/etc/cron.d and others are directories, and should have execute permission.

Actually I have just gone into the original CIS document, and it's inconsistent. It says permissions should be 0600 (u=rw instead of u=rwx) but it remediates by setting go-rwx, which does not do u-x.

You may not want to merge this since it does not strictly conform to CIS. I'll raise an issue with them.