### PR TITLE
Adds latest Amazon Linux 2017.03

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,6 +5,7 @@ cis_target_os_distribution: "Amazon"
 cis_target_os_versions: 
   - "2016.03"
   - "2016.09"
+  - "2017.03"
 
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_aide_database_filename: "/var/lib/aide/aide.db.gz"


### PR DESCRIPTION
When trying to run this playbook against the newly launched Amazon Linux 2017.03 (``ami-ea08368c`` in Ireland region) I noticed Preflight has a check and it failed the run.

This PR adds the latest Amazon Linux to the whitelisted versions as this playbook continues to work fine with it - Got over 100+ changes without any issue

Thanks!!


