### PR TITLE
Corrected search for SUID executables

### DIFF
--- a/tasks/level-1/6.1.13.yml
+++ b/tasks/level-1/6.1.13.yml
@@ -4,7 +4,7 @@
 # 6.1.13 Audit SUID executables
 
 - name: 6.1.13 - Check if any SUID executables exist
-  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup
+  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000
   register: audit_6_1_13
   tags:
     - level-1


### PR DESCRIPTION
This matched on files belonging to no group, and not on SUID executables as intended. I suppose it was a template copy-paste from the previous file that should have been updated according to the purposes of this test.

It might be useful to add a list of validated executables to that one could turn on fail_on_manual_remediation_actions, would that interest you?