### PR TITLE
added support for Amazon Linux 2017.09

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ cis_target_os_versions:
   - "2016.03"
   - "2016.09"
   - "2017.03"
+  - "2017.09"
 
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_aide_database_filename: "/var/lib/aide/aide.db.gz"


### PR DESCRIPTION
recent run using this playbook resulted in the following error:
`AWS AMI Builder - CIS: fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "This benchmark is not suitable for the destination operating system"}`

The AMI that was retrieved was:
`AWS AMI Builder - CIS: Found Image ID: ami-81a3b9fa`

That AMI is version 2017.09:
`amzn-ami-vpc-nat-hvm-2017.09.rc-0.20170913-x86_64-ebs`