### PR TITLE
Corrected 5.4.4 to be correctly scored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.output
 tests/tmp
 tests/roles
+.idea

--- a/tasks/level-1/5.4.4.yml
+++ b/tasks/level-1/5.4.4.yml
@@ -4,9 +4,9 @@
 # 5.4.4 Ensure default user umask is 027 or more restrictive
 
 - name: 5.4.4 - Ensure default user umask is 027 or more restrictive
-  lineinfile:
-    regexp: "^umask\\s+"
-    line: "umask {{ cis_umask_default }}"
+  replace:
+    regexp: "umask\\s+\\d+"
+    replace: "umask {{ cis_umask_default }}"
     dest: "{{ item }}"
   with_items: "{{ cis_umask_shell_files }}"
   tags:


### PR DESCRIPTION
Changed 5.4.4 to change all umask settings in /etc/bashrc and /etc/profile to 027 added the line to the end of the file worked but the CIS scorer still marked it as failed with changing all umask settings in the file it marked it as passed.