### PR TITLE
Add opts to mounting tmpfs on 1.1.2

### DIFF
--- a/tasks/level-1/1.1.2.yml
+++ b/tasks/level-1/1.1.2.yml
@@ -9,8 +9,9 @@
     state: present
     fstype: "{{item.fstype}}"
     src: "{{item.device}}"
+    opts: "{{item.opts}}"
   with_items:
-    - { mountpoint: '/tmp', device: 'tmpfs', fstype: 'tmpfs' }
+    - { mountpoint: '/tmp', device: 'tmpfs', fstype: 'tmpfs', opts: 'rw,nosuid,nodev,noexec,relatime' }
   tags:
       - level-1
       - section-1


### PR DESCRIPTION
* Support the mount options `rw,nosuid,nodev,noexec,relatime` that CIS 2.1 requires for tmpfs
* Applying nodev, nosuid, noexec to `/tmp` does not work at 1.1.3~1.1.5 because `ansible_mounts` don't contain it which has been created at 1.1.2.