### PR TITLE
Add 2018.03 to the supported versions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,5 +13,6 @@ galaxy_info:
     - "2016.09"
     - "2017.03"
     - "2017.09"
+    - "2018.03"
   galaxy_tags: ['CIS','Linux','Amazon','hardening','benchmark','PCIDSS','compliance']
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - "2016.09"
     - "2017.03"
     - "2017.09"
-    - "2018.03"
+    - "2017.12"
+    - Candidate
   galaxy_tags: ['CIS','Linux','Amazon','hardening','benchmark','PCIDSS','compliance']
 dependencies: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,7 @@ cis_target_os_versions:
   - "2016.09"
   - "2017.03"
   - "2017.09"
+  - "2018.03"
 
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_aide_database_filename: "/var/lib/aide/aide.db.gz"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,8 @@ cis_target_os_versions:
   - "2016.09"
   - "2017.03"
   - "2017.09"
-  - "2018.03"
+  - "2017.12"
+  - Candidate
 
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_aide_database_filename: "/var/lib/aide/aide.db.gz"


### PR DESCRIPTION
This has already been tested and seems to be working fine. The main change in 2018.03 is the kernel support.