### PR TITLE
Fixes #36

### DIFF
--- a/tasks/level-1/5.5.yml
+++ b/tasks/level-1/5.5.yml
@@ -5,7 +5,7 @@
 
 - name: 5.5 - Ensure access to the su command is restricted
   lineinfile:
-    regexp: "^auth\\s+"
+    regexp: "^auth\\s.*\\spam_wheel.so\\s"
     line: "auth required pam_wheel.so use_uid"
     dest: "/etc/pam.d/su"
   tags:


### PR DESCRIPTION
The stanza "Ensure access to the su command is restricted" is supposed to ensure that only members of the wheel group may use `su`, by ensuring that the line "auth required pam_wheel.so use_uid" is present in the /etc/pam.d/su file, as recommended by section 5.5 of CIS for Amazon Linux.

Unfortunately, due to matching auth\s+, this stanza will replace the last one of any pre-existing lines starting with the word "auth". On my latest Amazon Linux there are three such lines:

```
auth	sufficient	pam_rootok.so
auth	substack	system-auth
auth include postlogin
```

Replacing the line `auth include postlogin` is certainly not intended by the applicable CIS 5.5. CIS 5.5 mandates that the required line should be the only one matching pam_wheel.so, not the only line matching `^auth\s`.

Fixing this by specifying that the replaced line must also contain `pam_wheel.so`, which ensures that the replacement will be made in the correct circumstances (both in my opinion and as described by CIS)