### PR TITLE
Fixed invalid rule error in L1 5.3.2

### DIFF
--- a/tasks/level-1/5.3.2.yml
+++ b/tasks/level-1/5.3.2.yml
@@ -70,7 +70,7 @@
     type: auth
     control: sufficient
     module_path: pam_unix.so
-    new_control: [success=1 default=bad]
+    new_control: '[success=1 default=bad]'
     module_arguments: ''
     state: updated
   tags:


### PR DESCRIPTION
The level 1 5.3.2 task `Ensure lockout for failed password attempts is configured(pam_unix.so)` was failing with the following error

```
TASK [anthcourtney.cis-amazon-linux : 5.3.2 - Ensure lockout for failed password attempts is configured(pam_unix.so)] ***
fatal: [amazon-linux-docker]: FAILED! => {"changed": false, "msg": "Rule control value, 'success, is not valid in rule auth       ['success=1 default=bad'] pam_unix.so "}
```

[ansible 2.6.3]