### PR TITLE
3.3.1-2 Trigger flush on IPv6 sysctl path after modifying IPv6 routing

### DIFF
--- a/tasks/level-1/3.3.1.yml
+++ b/tasks/level-1/3.3.1.yml
@@ -24,7 +24,7 @@
   with_items:
     - "sysctl -w net.ipv6.conf.all.accept_ra=0"
     - "sysctl -w net.ipv6.conf.default.accept_ra=0"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - "sysctl -w net.ipv6.route.flush=1"
   ignore_errors: true
   tags:
     - level-1

--- a/tasks/level-1/3.3.2.yml
+++ b/tasks/level-1/3.3.2.yml
@@ -24,7 +24,7 @@
   with_items:
     - "sysctl -w net.ipv6.conf.all.accept_redirects=0"
     - "sysctl -w net.ipv6.conf.default.accept_redirects=0"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - "sysctl -w net.ipv6.route.flush=1"
   ignore_errors: true
   tags:
     - level-1


### PR DESCRIPTION
Because we're modifying IPv6 related tunables, we should flush the IPv6 routes instead of IPv4