### PR TITLE
Bugfix/gather facts of non disk mounts

### DIFF
--- a/facts/all_mounts.py
+++ b/facts/all_mounts.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+
+##
+# all_mounts.fact
+# This is a custom fact that will gather all
+# mounts into a fact, ansible_mounts will only
+# get mounts that are tied to a physical device
+# that will leave out many mounts
+##
+
+import os
+import json
+
+##
+# get_file_content
+# gets the content of a file
+# path - the path to the file
+# default - the default return
+# strip - strip out whitespace
+##
+def get_file_content(path, default=None, strip=True):
+    data = default
+    if os.path.exists(path) and os.access(path, os.R_OK):
+        try:
+            try:
+                datafile = open(path)
+                data = datafile.read()
+                if strip:
+                    data = data.strip()
+                if len(data) == 0:
+                    data = default
+            finally:
+                datafile.close()
+        except:
+            pass
+    return data
+
+##
+# get_mtab_entries
+# gets the mtab entries to use
+##
+def get_mtab_entries():
+
+    mtab_file = '/etc/mtab'
+    if not os.path.exists(mtab_file):
+        mtab_file = '/proc/mounts'
+
+    mtab = get_file_content(mtab_file, '')
+    mtab_entries = []
+    for line in mtab.splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        mtab_entries.append(fields)
+    return mtab_entries
+
+## Main ##
+
+mtab_entries = get_mtab_entries()
+
+mounts = []
+
+for fields in mtab_entries:
+    device, mount, fstype, options = fields[0], fields[1], fields[2], fields[3]
+
+    mount_info = {
+        'mount': mount,
+        'device': device,
+        'fstype': fstype,
+        'options': options
+    }
+
+    mounts.append(mount_info)
+
+print json.dumps(mounts)

--- a/tasks/level-1/1.1.15.yml
+++ b/tasks/level-1/1.1.15.yml
@@ -3,13 +3,7 @@
 
 # 1.1.15 Ensure nodev option set on /dev/shm partition
 
-- name: 1.1.15 - Gather facts of all mounts, including non-disk mounts
-  script: facts/all_mounts.py
-  args:
-    executable: python
-  changed_when: false
-  check_mode: false
-  register: all_mounts
+- include: all_mounts_facts.yml
   tags:
     - level-1
     - section-1

--- a/tasks/level-1/1.1.15.yml
+++ b/tasks/level-1/1.1.15.yml
@@ -3,6 +3,19 @@
 
 # 1.1.15 Ensure nodev option set on /dev/shm partition
 
+- name: 1.1.15 - Gather facts of all mounts, including non-disk mounts
+  script: facts/all_mounts.py
+  args:
+    executable: python
+  changed_when: false
+  check_mode: false
+  register: all_mounts
+  tags:
+    - level-1
+    - section-1
+    - "1.1.15"
+    - scored
+
 - name: 1.1.15 - Ensure nodev option set on /dev/shm partition
   mount:
     name: "{{ item.mount }}"
@@ -11,7 +24,7 @@
     src: "{{ item.device }}"
     opts: "{{ item.options.split(',') | union(['nodev']) | join(',') }}"
   when: item.mount == '/dev/shm'
-  with_items: "{{ ansible_mounts }}"
+  with_items: "{{ all_mounts.stdout | default('{}') | from_json }}"
   tags:
     - level-1
     - section-1

--- a/tasks/level-1/1.1.16.yml
+++ b/tasks/level-1/1.1.16.yml
@@ -3,6 +3,19 @@
 
 # 1.1.16 Ensure nosuid option set on /dev/shm partition
 
+- name: 1.1.16 - Gather facts of all mounts, including non-disk mounts
+  script: facts/all_mounts.py
+  args:
+    executable: python
+  changed_when: false
+  check_mode: false
+  register: all_mounts
+  tags:
+    - level-1
+    - section-1
+    - "1.1.16"
+    - scored
+
 - name: 1.1.16 - Ensure nosuid option set on /dev/shm partition
   mount:
     name: "{{ item.mount }}"
@@ -11,7 +24,7 @@
     src: "{{ item.device }}"
     opts: "{{ item.options.split(',') | union(['nosuid']) | join(',') }}"
   when: item.mount == '/dev/shm'
-  with_items: "{{ ansible_mounts }}"
+  with_items: "{{ all_mounts.stdout | default('{}') | from_json }}"
   tags:
     - level-1
     - section-1

--- a/tasks/level-1/1.1.16.yml
+++ b/tasks/level-1/1.1.16.yml
@@ -3,13 +3,7 @@
 
 # 1.1.16 Ensure nosuid option set on /dev/shm partition
 
-- name: 1.1.16 - Gather facts of all mounts, including non-disk mounts
-  script: facts/all_mounts.py
-  args:
-    executable: python
-  changed_when: false
-  check_mode: false
-  register: all_mounts
+- include: all_mounts_facts.yml
   tags:
     - level-1
     - section-1

--- a/tasks/level-1/1.1.17.yml
+++ b/tasks/level-1/1.1.17.yml
@@ -3,13 +3,7 @@
 
 # 1.1.17 Ensure noexec option set on /dev/shm partition
 
-- name: 1.1.17 - Gather facts of all mounts, including non-disk mounts
-  script: facts/all_mounts.py
-  args:
-    executable: python
-  changed_when: false
-  check_mode: false
-  register: all_mounts
+- include: all_mounts_facts.yml
   tags:
     - level-1
     - section-1

--- a/tasks/level-1/1.1.17.yml
+++ b/tasks/level-1/1.1.17.yml
@@ -3,6 +3,19 @@
 
 # 1.1.17 Ensure noexec option set on /dev/shm partition
 
+- name: 1.1.17 - Gather facts of all mounts, including non-disk mounts
+  script: facts/all_mounts.py
+  args:
+    executable: python
+  changed_when: false
+  check_mode: false
+  register: all_mounts
+  tags:
+    - level-1
+    - section-1
+    - "1.1.17"
+    - scored
+
 - name: 1.1.17 - Ensure noexec option set on /dev/shm partition
   mount:
     name: "{{ item.mount }}"
@@ -11,7 +24,7 @@
     src: "{{ item.device }}"
     opts: "{{ item.options.split(',') | union(['noexec']) | join(',') }}"
   when: item.mount == '/dev/shm'
-  with_items: "{{ ansible_mounts }}"
+  with_items: "{{ all_mounts.stdout | default('{}') | from_json }}"
   tags:
     - level-1
     - section-1

--- a/tasks/level-1/all_mounts_facts.yml
+++ b/tasks/level-1/all_mounts_facts.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Gather facts of all mounts, including non-disk mounts
+  script: facts/all_mounts.py
+  args:
+    executable: python
+  changed_when: false
+  check_mode: false
+  register: all_mounts


### PR DESCRIPTION
As mentioned by @dgutierrez1287 in [this pull request](https://github.com/anthcourtney/ansible-role-cis-amazon-linux/pull/26), `ansible_mounts` does not contain facts about non-disk mounts which is a problem for tasks 1.1.15, 1.1.16 and 1.1.17 which define attributes for the `/dev/shm` mount which happens to be tmpfs. However, that pull request invokes the custom facts in a way that would not have the desired effect because the facts are not copied to the managed node, where ansible expects custom facts to be defined.

In this PR, I've used @dgutierrez1287's wonderful `all_mounts` fact script in a different way which allows the script to be run on the target host, and registered for use by the control node.